### PR TITLE
change: Add curve representations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,25 +1,46 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": ".NET Core Launch (console)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/test/bin/Debug/netcoreapp3.1/CoreByFloors.Tests.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/test",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/test/bin/Debug/netcoreapp3.1/CoreByFloors.Tests.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/test",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    },
+    {
+      "name": "Attach to Hypar Run",
+      "type": "coreclr",
+      "request": "attach",
+      "processName": "CoreByFloors.Server"
+    },
+    {
+      "name": "Launch Hypar Run (Run once only)",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/server/bin/Debug/net6.0/CoreByFloors.Server.dll",
+      "args": [
+        "--workflow-id",
+        "${input:workflowId}"
+      ],
+      "preLaunchTask": "server-build"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "workflowId",
+      "type": "promptString",
+      "description": "Enter the workflow id to run."
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,42 +1,52 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "build",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/test/CoreByFloors.Tests.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "publish",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "publish",
-                "${workspaceFolder}/test/CoreByFloors.Tests.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "watch",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "watch",
-                "run",
-                "${workspaceFolder}/test/CoreByFloors.Tests.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        }
-    ]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/test/CoreByFloors.Tests.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/test/CoreByFloors.Tests.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "${workspaceFolder}/test/CoreByFloors.Tests.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "server-build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/server/CoreByFloors.Server.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Creates a schematic building core.
 
 |Input Name|Type|Description|
 |---|---|---|
+|Additional Core Locations|array|Specify additional core locations|
 |Length|number|The default length of the core.|
 |Width|number|The default width of the core.|
-|Additional Core Locations|array|Specify additional core locations|
 
 
 <br>

--- a/dependencies/CoreArea.g.cs
+++ b/dependencies/CoreArea.g.cs
@@ -27,11 +27,12 @@ namespace Elements
     public partial class CoreArea : SpaceBoundary
     {
         [JsonConstructor]
-        public CoreArea(System.Guid @core, Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform, Material @material, Representation @representation, bool @isElementDefinition, System.Guid @id, string @name)
-            : base(boundary, cells, area, length, depth, height, programGroup, programType, level, levelLayout, hyparSpaceType, transform, material, representation, isElementDefinition, id, name)
+        public CoreArea(System.Guid @core, Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform, Material @material, Representation @representation, bool @isElementDefinition, System.Guid @id, string @name)
+            : base(boundary, cells, area, length, depth, height, programGroup, programType, programRequirement, level, levelLayout, hyparSpaceType, transform, material, representation, isElementDefinition, id, name)
         {
             this.Core = @core;
             }
+        
         
         // Empty constructor
         public CoreArea()

--- a/dependencies/CoreByFloors.Dependencies.csproj
+++ b/dependencies/CoreByFloors.Dependencies.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="2.0.0-alpha.17" />
-    <PackageReference Include="Hypar.Functions" Version="1.6.0" />
+    <PackageReference Include="Hypar.Elements" Version="2.1.0-alpha.23" />
+    <PackageReference Include="Hypar.Functions" Version="1.9.0-alpha.3" />
   </ItemGroup>
 </Project>

--- a/dependencies/CoreByFloorsInputs.g.cs
+++ b/dependencies/CoreByFloorsInputs.g.cs
@@ -29,18 +29,18 @@ namespace CoreByFloors
     {
         [Newtonsoft.Json.JsonConstructor]
         
-        public CoreByFloorsInputs(double @length, double @width, IList<Vector3> @additionalCoreLocations, Overrides @overrides, string bucketName, string uploadsBucket, Dictionary<string, string> modelInputKeys, string gltfKey, string elementsKey, string ifcKey):
+        public CoreByFloorsInputs(IList<Vector3> @additionalCoreLocations, double @length, double @width, Overrides @overrides, string bucketName, string uploadsBucket, Dictionary<string, string> modelInputKeys, string gltfKey, string elementsKey, string ifcKey):
         base(bucketName, uploadsBucket, modelInputKeys, gltfKey, elementsKey, ifcKey)
         {
             var validator = Validator.Instance.GetFirstValidatorForType<CoreByFloorsInputs>();
             if(validator != null)
             {
-                validator.PreConstruct(new object[]{ @length, @width, @additionalCoreLocations, @overrides});
+                validator.PreConstruct(new object[]{ @additionalCoreLocations, @length, @width, @overrides});
             }
         
+            this.AdditionalCoreLocations = @additionalCoreLocations;
             this.Length = @length;
             this.Width = @width;
-            this.AdditionalCoreLocations = @additionalCoreLocations;
             this.Overrides = @overrides ?? this.Overrides;
         
             if(validator != null)
@@ -49,19 +49,19 @@ namespace CoreByFloors
             }
         }
     
+        /// <summary>Specify additional core locations</summary>
+        [Newtonsoft.Json.JsonProperty("Additional Core Locations", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Vector3> AdditionalCoreLocations { get; set; }
+    
         /// <summary>The default length of the core.</summary>
         [Newtonsoft.Json.JsonProperty("Length", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.Range(1.0D, 50D)]
+        [System.ComponentModel.DataAnnotations.Range(1D, 50D)]
         public double Length { get; set; } = 18D;
     
         /// <summary>The default width of the core.</summary>
         [Newtonsoft.Json.JsonProperty("Width", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.Range(1.0D, 50D)]
+        [System.ComponentModel.DataAnnotations.Range(1D, 50D)]
         public double Width { get; set; } = 10D;
-    
-        /// <summary>Specify additional core locations</summary>
-        [Newtonsoft.Json.JsonProperty("Additional Core Locations", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public IList<Vector3> AdditionalCoreLocations { get; set; }
     
         [Newtonsoft.Json.JsonProperty("overrides", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Overrides Overrides { get; set; } = new Overrides();
@@ -417,12 +417,12 @@ namespace CoreByFloors
     
         /// <summary>The default length of the core.</summary>
         [Newtonsoft.Json.JsonProperty("Length", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.Range(1.0D, 50D)]
+        [System.ComponentModel.DataAnnotations.Range(1D, 50D)]
         public double Length { get; set; }
     
         /// <summary>The default depth of the core.</summary>
         [Newtonsoft.Json.JsonProperty("Depth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.Range(1.0D, 50D)]
+        [System.ComponentModel.DataAnnotations.Range(1D, 50D)]
         public double Depth { get; set; }
     
     }

--- a/dependencies/LevelVolume.g.cs
+++ b/dependencies/LevelVolume.g.cs
@@ -39,6 +39,7 @@ namespace Elements
             this.PlanView = @planView;
             }
         
+        
         // Empty constructor
         public LevelVolume()
             : base()

--- a/dependencies/ServiceCore.g.cs
+++ b/dependencies/ServiceCore.g.cs
@@ -36,6 +36,7 @@ namespace Elements
             this.Centroid = @centroid;
             }
         
+        
         // Empty constructor
         public ServiceCore()
             : base()

--- a/dependencies/SpaceBoundary.g.cs
+++ b/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -38,10 +38,12 @@ namespace Elements
             this.Height = @height;
             this.ProgramGroup = @programGroup;
             this.ProgramType = @programType;
+            this.ProgramRequirement = @programRequirement;
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
             }
+        
         
         // Empty constructor
         public SpaceBoundary()
@@ -78,8 +80,11 @@ namespace Elements
         public string ProgramGroup { get; set; }
     
         /// <summary>The name of the program type assigned to this space (like "Open Office" or "Meeting Room")</summary>
-        [JsonProperty("Program Type", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Program Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ProgramType { get; set; }
+    
+        [JsonProperty("Program Requirement", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Guid? ProgramRequirement { get; set; }
     
         [JsonProperty("Level", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? Level { get; set; }

--- a/hypar.json
+++ b/hypar.json
@@ -1,54 +1,60 @@
 {
-  "$schema": "https://hypar.io/Schemas/function.json",
+  "$schema": "https://hypar.io/Schemas/Function.json",
   "id": "a9cac5a1-f68d-4d2e-bfdd-0d204359bbe4",
   "name": "Core By Floors",
+  "description": "Creates a schematic building core.",
+  "language": "C#",
   "model_dependencies": [
     {
+      "autohide": false,
       "name": "Floors",
       "optional": true
     },
     {
+      "autohide": false,
       "name": "Levels",
       "optional": true
     },
     {
+      "autohide": false,
       "name": "Conceptual Mass",
       "optional": true
     }
   ],
   "model_output": "Core",
-  "description": "Creates a schematic building core.",
-  "language": "C#",
   "input_schema": {
     "type": "object",
     "properties": {
-      "Length": {
-        "$hyparDeprecated": true,
-        "type": "number",
-        "description": "The default length of the core.",
-        "minimum": 1.0,
-        "maximum": 50,
-        "default": 18,
-        "multipleOf": 0.1,
-        "$hyparUnitType": "length"
-      },
-      "Width": {
-        "$hyparDeprecated": true,
-        "type": "number",
-        "description": "The default width of the core.",
-        "minimum": 1.0,
-        "maximum": 50,
-        "default": 10,
-        "multipleOf": 0.1,
-        "$hyparUnitType": "length"
-      },
       "Additional Core Locations": {
+        "description": "Specify additional core locations",
         "$hyparDeprecated": true,
         "type": "array",
-        "description": "Specify additional core locations",
+        "$hyparOrder": 2,
         "items": {
           "$ref": "https://hypar.io/Schemas/Geometry/Vector3.json"
         }
+      },
+      "Length": {
+        "multipleOf": 0.1,
+        "default": 18,
+        "$hyparDeprecated": true,
+        "description": "The default length of the core.",
+        "maximum": 50,
+        "type": "number",
+        "$hyparUnitType": "length",
+        "$hyparOrder": 0,
+        "minimum": 1
+      },
+      "Width": {
+        "multipleOf": 0.1,
+        "default": 10,
+        "$hyparDeprecated": true,
+        "description": "The default width of the core.",
+        "maximum": 50,
+        "type": "number",
+        "$hyparUnitType": "length",
+        "$hyparOrder": 1,
+        "minimum": 1
       }
     }
   },
@@ -64,16 +70,7 @@
           "format": "uuid"
         }
       },
-      "behaviors": {
-        "add": {
-          "schema": {
-            "Profile": {
-              "$ref": "https://hypar.io/Schemas/Geometry/Polygon.json"
-            }
-          }
-        },
-        "remove": true
-      },
+      "paradigm": "edit",
       "schema": {
         "Profile": {
           "type": "object",
@@ -83,6 +80,23 @@
             }
           }
         }
+      },
+      "verbs": {
+        "add": null,
+        "remove": null,
+        "edit": null,
+        "revert": null
+      },
+      "dependency": null,
+      "behaviors": {
+        "add": {
+          "schema": {
+            "Profile": {
+              "$ref": "https://hypar.io/Schemas/Geometry/Polygon.json"
+            }
+          }
+        },
+        "remove": true
       }
     },
     "Core Dimensions": {
@@ -96,39 +110,50 @@
           "format": "uuid"
         }
       },
+      "paradigm": "edit",
       "schema": {
         "Length": {
-          "type": "number",
-          "description": "The default length of the core.",
-          "minimum": 1.0,
-          "maximum": 50,
           "multipleOf": 0.1,
-          "$hyparUnitType": "length"
+          "description": "The default length of the core.",
+          "maximum": 50,
+          "type": "number",
+          "$hyparUnitType": "length",
+          "$hyparOrder": 0,
+          "minimum": 1
         },
         "Depth": {
-          "type": "number",
-          "description": "The default depth of the core.",
-          "minimum": 1.0,
-          "maximum": 50,
           "multipleOf": 0.1,
-          "$hyparUnitType": "length"
+          "description": "The default depth of the core.",
+          "maximum": 50,
+          "type": "number",
+          "$hyparUnitType": "length",
+          "$hyparOrder": 1,
+          "minimum": 1
         }
-      }
-    }
-  },
-  "messages": {
-    "en": {
-      "name": "Core"
+      },
+      "verbs": {
+        "add": null,
+        "remove": null,
+        "edit": null,
+        "revert": null
+      },
+      "dependency": null,
+      "behaviors": null
     }
   },
   "outputs": [],
-  "repository_url": "https://github.com/hypar-io/function",
-  "source_file_key": null,
-  "preview_image": null,
   "element_types": [
     "https://prod-api.hypar.io/schemas/ServiceCore",
     "https://prod-api.hypar.io/schemas/LevelVolume",
     "https://prod-api.hypar.io/schemas/SpaceBoundary",
     "https://prod-api.hypar.io/schemas/CoreArea"
-  ]
+  ],
+  "repository_url": "https://github.com/hypar-io/function",
+  "last_updated": "2023-04-27T15:52:55.967423",
+  "cli_version": "1.9.0-alpha.3",
+  "messages": {
+    "en": {
+      "name": "Core"
+    }
+  }
 }

--- a/server/CoreByFloors.Server.csproj
+++ b/server/CoreByFloors.Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\CoreByFloors.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hypar.Server" Version="1.9.0-alpha.3" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,0 +1,26 @@
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace Hypar.Server
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            await HyparServer.StartAsync(
+                args,
+                Path.GetFullPath(Path.Combine(Assembly.GetExecutingAssembly().Location, "../../../../..")),
+                async (executionRequest) =>
+                {
+                    var input = executionRequest.Args.ToObject<CoreByFloors.CoreByFloorsInputs>();
+                    var function = new CoreByFloors.Function();
+                    Directory.SetCurrentDirectory(Path.GetDirectoryName(typeof(CoreByFloors.Function).Assembly.Location)!);
+                    return await function.Handler(input, null);
+                });
+        }
+    }
+}

--- a/src/CoreByFloors.cs
+++ b/src/CoreByFloors.cs
@@ -169,7 +169,7 @@ namespace CoreByFloors
 
                             var boundary = coreInThisGroup.Value.Profile.Perimeter;
                             var rep = new Representation(new[] { new Extrude(boundary, matchingExistingCore.Height, Vector3.ZAxis, false) });
-                            var overrideCore = new Elements.ServiceCore(boundary, 0, matchingExistingCore.Height, coreInThisGroup.Identity.Centroid, new Transform(0, 0, minHeight), BuiltInMaterials.Concrete, rep, false, Guid.NewGuid(), null);
+                            var overrideCore = new ServiceCore(boundary, 0, matchingExistingCore.Height, coreInThisGroup.Identity.Centroid, new Transform(0, 0, minHeight), BuiltInMaterials.Concrete, rep, false, Guid.NewGuid(), null);
                             Identity.AddOverrideIdentity(overrideCore, "Cores", coreInThisGroup.Id, coreInThisGroup.Identity);
                             allCores.Remove(matchingExistingCore);
                             overrideCore.BoundaryIsUnedited = false;
@@ -217,6 +217,15 @@ namespace CoreByFloors
                             var coreLines = new CoreLines(core.Profile, level.Transform);
                             output.Model.AddElements(sb, coreLines);
                         }
+
+                        // Add curve representations so that core are visible in plan views.
+                        // Ideally, this would look like an outline around all of the core edges.
+                        // This is simply putting curve around the top and bottom of the extruded solid.
+                        core.RepresentationInstances = new List<RepresentationInstance>{
+                            new(new CurveRepresentation(core.Profile.Perimeter.TransformedPolygon(new Transform(new Vector3(0, 0, core.Height))), false), BuiltInMaterials.Black),
+                            new(new SolidRepresentation(new Extrude(core.Profile, core.Height, Vector3.ZAxis, false)), BuiltInMaterials.Concrete),
+                            new(new CurveRepresentation(core.Profile.Perimeter, false), BuiltInMaterials.Black)
+                        };
                     }
                 }
                 output.Model.AddElements(allCores);

--- a/src/Function.g.cs
+++ b/src/Function.g.cs
@@ -61,11 +61,18 @@ namespace CoreByFloors
             Console.WriteLine($"Time to load assemblies: {sw.Elapsed.TotalSeconds})");
 
             if(this.store == null)
-            {
-                this.store = new S3ModelStore<CoreByFloorsInputs>(RegionEndpoint.GetBySystemName("us-west-1"));
+            { 
+                if (args.SignedResourceUrls == null)
+                {
+                    this.store = new S3ModelStore<CoreByFloorsInputs>(RegionEndpoint.GetBySystemName("us-west-1"));
+                }
+                else
+                {
+                    this.store = new UrlModelStore<CoreByFloorsInputs>();
+                }
             }
 
-            var l = new InvocationWrapper<CoreByFloorsInputs,CoreByFloorsOutputs>(store, CoreByFloors.Execute);
+            var l = new InvocationWrapper<CoreByFloorsInputs,CoreByFloorsOutputs> (store, CoreByFloors.Execute);
             var output = await l.InvokeAsync(args);
             return output;
         }


### PR DESCRIPTION
When viewing cores with floors in a plan view, it was unclear where the boundaries of the core were because the floor and core functions use the same material in their representations.

- Adds curve representations to the top and bottom of each core
- Updates the Elements and Functions versions of the function

![Screenshot 2023-10-12 at 1 56 58 PM](https://github.com/hypar-io/CoreByFloors/assets/34290772/ba0be721-50ce-49b2-beb6-b3651dd8149f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/CoreByFloors/1)
<!-- Reviewable:end -->
